### PR TITLE
Ruby solutions

### DIFF
--- a/Week002/rudyjahchan/goal1.rb
+++ b/Week002/rudyjahchan/goal1.rb
@@ -1,0 +1,11 @@
+def g(tail=nil)
+  if tail
+    "g#{tail}"
+  else
+    Class.new(String) do
+      def o(tail='')
+        self.class.new(self + 'o' + tail)
+      end
+    end.new 'g'
+  end
+end

--- a/Week002/rudyjahchan/goal1_spec.rb
+++ b/Week002/rudyjahchan/goal1_spec.rb
@@ -1,0 +1,29 @@
+require 'minitest/autorun'
+require 'minitest/spec'
+require './goal1'
+
+describe '#g' do
+  describe 'given repeated calls of o' do
+    subject { g.o.o.o.o.o 'al' }
+
+    it 'returns a string containing that number of o' do
+      subject.must_equal 'goooooal'
+    end
+  end
+
+  describe 'given one call of o' do
+    subject { g.o 'al' }
+
+    it 'returns a string containing that number of o' do
+      subject.must_equal 'goal'
+    end
+  end
+
+  describe 'given a string' do
+    subject { g 'al' }
+
+    it 'prepends g to the string' do
+      subject.must_equal 'gal'
+    end
+  end
+end

--- a/Week002/rudyjahchan/goal2.rb
+++ b/Week002/rudyjahchan/goal2.rb
@@ -1,0 +1,7 @@
+def g(tail)
+  "g#{tail}"
+end
+
+def o(tail)
+  "o#{tail}"
+end

--- a/Week002/rudyjahchan/goal2_spec.rb
+++ b/Week002/rudyjahchan/goal2_spec.rb
@@ -1,0 +1,29 @@
+require 'minitest/autorun'
+require 'minitest/spec'
+require './goal2'
+
+describe 'goal2' do
+  describe 'given repeated calls of o' do
+    subject { g o o o o o 'al' }
+
+    it 'returns a string containing that number of o' do
+      subject.must_equal 'goooooal'
+    end
+  end
+
+  describe 'given one call of o' do
+    subject { g o 'al' }
+
+    it 'returns a string containing that number of o' do
+      subject.must_equal 'goal'
+    end
+  end
+
+  describe 'given a string' do
+    subject { g 'al' }
+
+    it 'prepends g to the string' do
+      subject.must_equal 'gal'
+    end
+  end
+end

--- a/Week002/rudyjahchan/goal3.rb
+++ b/Week002/rudyjahchan/goal3.rb
@@ -1,0 +1,11 @@
+def g(tail=nil)
+  if tail
+    "g#{tail}"
+  else
+    def o(head)
+      ->(tail=nil){ tail ? head + tail : o(head + 'o') }
+    end
+
+    o 'g'
+  end
+end

--- a/Week002/rudyjahchan/goal3_spec.rb
+++ b/Week002/rudyjahchan/goal3_spec.rb
@@ -1,0 +1,29 @@
+require 'minitest/autorun'
+require 'minitest/spec'
+require './goal3'
+
+describe '#g' do
+  describe 'given repeated calls of o' do
+    subject { g.().().().().().('al')}
+
+    it 'returns a string containing that number of o' do
+      subject.must_equal 'goooooal'
+    end
+  end
+
+  describe 'given one call of o' do
+    subject { g.().('al') }
+
+    it 'returns a string containing that number of o' do
+      subject.must_equal 'goal'
+    end
+  end
+
+  describe 'given a string' do
+    subject { g 'al' }
+
+    it 'prepends g to the string' do
+      subject.must_equal 'gal'
+    end
+  end
+end


### PR DESCRIPTION
This is a number of possible Ruby based solutions for Week 2's challenge. Generally, as there seems to be no way to return and invoke a method without the dot marker (i.e. you can't do `foo()()()`).

Solution 1 (`goal1.rb`) follows the pattern @laser used where repeated invocations of `o` adds 'o' characters:

``` irb
irb(main):001:0> require './goal1.rb'
=> true
irb(main):002:0> g.o.o.o.o.o.o.o 'al'
=> "goooooooal"
irb(main):003:0> g.o 'al'
=> "goal"
irb(main):004:0> g 'al'
=> "gal"
```

It uses an enclosed class that extends `String` and adds an `o` method. To keep it "functional", I made sure it wouldn't modify an original String passed in, but create a new method.

Solution 2 (`goal2.rb`) is similar in invocation, but drops the dots:

``` irb
irb(main):001:0> require './goal2'
=> true
irb(main):002:0> g o o o o o o o 'al'
=> "goooooooal"
irb(main):003:0> g o 'al'
=> "goal"
irb(main):004:0> g 'al'
=> "gal"
```

This is the most functional in implementation, introducing `g` and `o` methods that simply prepend their appropriate character to any passed value.

Finally the third solution (`goal3.rb`) was an exercise in getting closer to the original challenge:

``` irb
irb(main):001:0> require './goal3.rb'
=> true
irb(main):002:0> g.().().().().().().().('al')
=> "goooooooal"
irb(main):004:0> g.().('al')
=> "goal"
irb(main):005:0> g.('al')
=> "gal"
irb(main):006:0> g 'al'
=> "gal"
```

It relies on the fact that Ruby lambdas can be invoked via `.()`, so the `g` method returns a lambda whose invocation will return a similar lambda.

Final note that solution's 1 and 3 have a conditional to avoid returning a class or lamba right away, to again match more closely what was originally requested; in solution 1, this avoids the possibility of g('al').o being a valid answer, while in solution 3 I just wanted to be able to call the it once without parenthesis(sp?).
